### PR TITLE
[Repo Config] Add pre-push hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,3 @@
-fail_fast: false
 repos:
   - repo: local # https://github.com/natsunoyoru97/cpp-simple-database.git
     hooks:
@@ -6,15 +5,15 @@ repos:
         name: clang-format
         entry: clang-format
         language: system
+        stages: [push]
         args: ["--style=Google"]
-      #- id: oclint
-      #- id: uncrustify
       - id: cppcheck
         name: cppcheck
         entry: cppcheck
         language: system
+        stages: [push]
       - id: cpplint
         name: cpplint
         entry: cpplint
         language: system
-      #- id: include-what-you-use
+        stages: [push]

--- a/README.md
+++ b/README.md
@@ -12,3 +12,10 @@ xmake
 xmake run target
 - Run test: 
 xmake run test
+
+### Setup pre-push hook
+- Install a few binary for C++ language: `clang-format`, `cppcheck`, `cpplint`
+- Install pre-push hook:
+```
+pre-commit install -t pre-push
+```


### PR DESCRIPTION
Add simple instructions on how to set-up pre-push hook.

I intentionally wrote some C++ code which breaks linter format.
After applying the pre-push hook, lint error looks like:
```
hjiang@hjiang-laptop cpp-simple-database % git add *
hjiang@hjiang-laptop cpp-simple-database % git commit -m "Random commit"
[hjiang/set-up-pre-commit-hook c4140d8] Random commit
 1 file changed, 2 insertions(+), 2 deletions(-)
hjiang@hjiang-laptop cpp-simple-database % git push
clang-format.............................................................Passed
cppcheck.................................................................Passed
cpplint..................................................................Failed
- hook id: cpplint
- exit code: 1

src/main.cpp:10:  Lines should be <= 80 characters long  [whitespace/line_length] [2]
src/main.cpp:10:  Missing space after ;  [whitespace/semicolon] [3]
Done processing src/main.cpp
Total errors found: 2

error: failed to push some refs to 'github.com:natsunoyoru97/cpp-simple-database.git'
``` 