### PR TITLE
[Repo Config] Enfore C++ standard

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -1,5 +1,6 @@
-add_requires("doctest", "gtest")
+set_languages("c++17")
 
+add_requires("doctest", "gtest ~1.12.1")
 add_rules("mode.debug", "mode.release")
 
 target("target")


### PR DESCRIPTION
Add one line to enforce the C++ standard to C++17 in xmake.lua:
```
set_languages("c++17")
```
This configuration is like the cmake specification like below to enforce the C++ standard:
```
target_compile_features(target PRIVATE cxx_std_17)
```