### PR TITLE
[Repo Config] Add Packages: glog, gflags and abseil

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,14 @@
 #include <algorithm>
 #include <iostream>
 #include <vector>
+#include <signal.h>
+#include <sys/signal.h>
+
+#include <glog/logging.h>
+#include <gflags/gflags.h>
+#include "absl/strings/str_join.h"
+
+DEFINE_string(test, "simple database", "the flag for test");
 
 // Tokenizer that takes the space as the delimiter
 std::vector<std::string> Tokenize(const std::string& s) {
@@ -74,8 +82,33 @@ void ExecuteDb(const std::string& command,
   }
 }
 
+// The signal handler for SIGPIPE
+void DoNothing(int signum) { /* Ignore SIGPIPE */ }
+
+void InitGlog(const char* argv0) {
+    google::InitGoogleLogging(argv0);
+}
+
+void InitGflags() {
+    // TODO: Use glog to replace the cout
+    std::cout << FLAGS_test << "\n";
+}
+
+void InitAbseil() {
+    std::vector<std::string> vec { "hello", "world" };
+    std::string s;
+    s = absl::StrJoin(vec, " ");
+
+    // TODO: Use glog to replace the cout
+    std::cout << s << "\n";
+}
+
 int main(int argc, char** argv) {
-  std::cout << "Simple database" << std::endl;
+  InitGlog(argv[0]);
+  InitGflags();
+  InitAbseil();
+
+  signal(SIGPIPE, DoNothing);
 
   while (true) {
     std::string command;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,19 +88,12 @@ void DoNothing(int signum) {
             << "\n"; /* Ignore SIGPIPE */
 }
 
+// TODO: redirect glog to stderr
 void InitGlog(const char* argv0) { google::InitGoogleLogging(argv0); }
 
 void InitGflags() {
   // TODO(natsunoyoru97): Use glog to replace the cout
   std::cout << FLAGS_test << "\n";
-}
-
-void InitAbseil() {
-  std::vector<std::string> vec{"hello", "world"};
-  std::string s = absl::StrJoin(vec, " ");
-
-  // TODO(natsunoyoru97): Use glog to replace the cout
-  std::cout << s << "\n";
 }
 
 int main(int argc, char** argv) {
@@ -111,7 +104,6 @@ int main(int argc, char** argv) {
 
   InitGlog(argv[0]);
   InitGflags();
-  InitAbseil();
 
   while (true) {
     std::string command;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,7 +88,7 @@ void DoNothing(int signum) {
             << "\n"; /* Ignore SIGPIPE */
 }
 
-// TODO: redirect glog to stderr
+// TODO(natsunoyoru97): redirect glog to stderr
 void InitGlog(const char* argv0) { google::InitGoogleLogging(argv0); }
 
 void InitGflags() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -91,7 +91,7 @@ void DoNothing(int signum) {
 void InitGlog(const char* argv0) { google::InitGoogleLogging(argv0); }
 
 void InitGflags() {
-  // TODO: Use glog to replace the cout
+  // TODO(natsunoyoru97): Use glog to replace the cout
   std::cout << FLAGS_test << "\n";
 }
 
@@ -99,12 +99,12 @@ void InitAbseil() {
   std::vector<std::string> vec{"hello", "world"};
   std::string s = absl::StrJoin(vec, " ");
 
-  // TODO: Use glog to replace the cout
+  // TODO(natsunoyoru97): Use glog to replace the cout
   std::cout << s << "\n";
 }
 
 int main(int argc, char** argv) {
-  /* TODO: It seems that the result is not as expected.
+  /* TODO(natsunoyoru97): It seems that the result is not as expected.
    It is a bug to fix.
    */
   std::signal(SIGPIPE, DoNothing);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,13 +1,13 @@
 // Copyright 2022 natsunoyoru97
 
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+
 #include <algorithm>
+#include <csignal>
 #include <iostream>
 #include <vector>
-#include <signal.h>
-#include <sys/signal.h>
 
-#include <glog/logging.h>
-#include <gflags/gflags.h>
 #include "absl/strings/str_join.h"
 
 DEFINE_string(test, "simple database", "the flag for test");
@@ -83,32 +83,35 @@ void ExecuteDb(const std::string& command,
 }
 
 // The signal handler for SIGPIPE
-void DoNothing(int signum) { /* Ignore SIGPIPE */ }
-
-void InitGlog(const char* argv0) {
-    google::InitGoogleLogging(argv0);
+void DoNothing(int signum) {
+  std::cout << "SIGPIPE"
+            << "\n"; /* Ignore SIGPIPE */
 }
 
+void InitGlog(const char* argv0) { google::InitGoogleLogging(argv0); }
+
 void InitGflags() {
-    // TODO: Use glog to replace the cout
-    std::cout << FLAGS_test << "\n";
+  // TODO: Use glog to replace the cout
+  std::cout << FLAGS_test << "\n";
 }
 
 void InitAbseil() {
-    std::vector<std::string> vec { "hello", "world" };
-    std::string s;
-    s = absl::StrJoin(vec, " ");
+  std::vector<std::string> vec{"hello", "world"};
+  std::string s = absl::StrJoin(vec, " ");
 
-    // TODO: Use glog to replace the cout
-    std::cout << s << "\n";
+  // TODO: Use glog to replace the cout
+  std::cout << s << "\n";
 }
 
 int main(int argc, char** argv) {
+  /* TODO: It seems that the result is not as expected.
+   It is a bug to fix.
+   */
+  std::signal(SIGPIPE, DoNothing);
+
   InitGlog(argv[0]);
   InitGflags();
   InitAbseil();
-
-  signal(SIGPIPE, DoNothing);
 
   while (true) {
     std::string command;

--- a/xmake.lua
+++ b/xmake.lua
@@ -6,7 +6,7 @@ add_rules("mode.debug", "mode.release")
 target("target")
     set_kind("binary")
     add_files("src/*.cpp")
-    add_packages("glog", "gflags")
+    add_packages("abseil", "glog", "gflags")
 
 target("test")
     set_kind("binary")

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,6 +1,6 @@
 set_languages("c++17")
 
-add_requires("doctest", "gtest ~1.12.1")
+add_requires("doctest", "gtest ~1.12.1", "glog", "gflags")
 add_rules("mode.debug", "mode.release")
 
 target("target")

--- a/xmake.lua
+++ b/xmake.lua
@@ -6,6 +6,7 @@ add_rules("mode.debug", "mode.release")
 target("target")
     set_kind("binary")
     add_files("src/*.cpp")
+    add_packages("glog", "gflags")
 
 target("test")
     set_kind("binary")

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,5 +1,6 @@
-add_requires("doctest", "gtest")
+set_languages("c++17")
 
+add_requires("doctest", "gtest ~1.12.1")
 add_rules("mode.debug", "mode.release")
 
 target("target")

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,6 +1,6 @@
 set_languages("c++17")
 
-add_requires("doctest", "gtest ~1.12.1", "glog", "gflags")
+add_requires("abseil", "doctest", "gtest ~1.12.1", "glog", "gflags")
 add_rules("mode.debug", "mode.release")
 
 target("target")


### PR DESCRIPTION
### Why we have the PR
- The c++ default iostream is not good to use and the third-party library is in need, here we use `glog` to do this.
- `gflags` is the library to parse the flags of the command.
- `abseil` is a C++ utility library to make code easier to write, e.g. to join the string in a vector.

### What this PR did
- Import three packages by xmake: `glog`, `gflags`, `abseil`

### Testcase
There are three functions altogether that start with "Init", and two of them test whether the packages are successfully imported:

```C++
/// TODO(natsunoyoru97): redirect glog to stderr
void InitGlog(const char* argv0) { google::InitGoogleLogging(argv0); }

void InitGflags() {
  // TODO(natsunoyoru97): Use glog to replace the cout
  std::cout << FLAGS_test << "\n";
}

void InitAbseil() {
  std::vector<std::string> vec{"hello", "world"};
  std::string s = absl::StrJoin(vec, " ");

  // TODO(natsunoyoru97): Use glog to replace the cout
  std::cout << s << "\n";
}
```