### PR TITLE
[Repo Config] bind glog to the stderr

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,8 +12,9 @@
 
 DEFINE_string(test, "simple database", "the flag for test");
 
+namespace {
 // Tokenizer that takes the space as the delimiter
-static std::vector<std::string> Tokenize(const std::string& s) {
+std::vector<std::string> Tokenize(const std::string& s) {
   std::vector<std::string> tokens;
   std::string curr;
   for (char c : s) {
@@ -35,7 +36,7 @@ static std::vector<std::string> Tokenize(const std::string& s) {
   return tokens;
 }
 
-static void Select(const std::vector<std::string>& params) {
+void Select(const std::vector<std::string>& params) {
   LOG(INFO) << "This is select function." << std::endl;
 
   for (const std::string& s : params) {
@@ -44,15 +45,15 @@ static void Select(const std::vector<std::string>& params) {
   LOG(INFO) << "\n";
 }
 
-static void Insert(const std::vector<std::string>& params) {
+void Insert(const std::vector<std::string>& params) {
   LOG(INFO) << "This is insert function." << params[0] << std::endl;
 }
 
-static void Delete(const std::vector<std::string>& params) {
+void Delete(const std::vector<std::string>& params) {
   LOG(INFO) << "This is delete function." << params[0] << std::endl;
 }
 
-static void ExecuteDb(const std::string& command,
+void ExecuteDb(const std::string& command,
                const std::vector<std::string>& params) {
   if (command == "select") {
     Select(params);
@@ -82,19 +83,19 @@ static void ExecuteDb(const std::string& command,
   }
 }
 
-static void InitGlog(const char* argv0) {
+void InitGlog(const char* argv0) {
   google::InitGoogleLogging(argv0);
   FLAGS_logtostderr = 1;
 }
 
 // The string should bind to the stderr
-static void TestGlog() {
-  LOG(INFO) << "The string should bind to the stderr in glog format." << "\n";
+void TestGlog() {
+  LOG(INFO) << "The string should bind to the stderr in glog format."
+            << "\n";
 }
 
-static void InitGflags() {
-  LOG(INFO) << FLAGS_test << "\n";
-}
+void InitGflags() { LOG(INFO) << FLAGS_test << "\n"; }
+}  // namespace
 
 int main(int argc, char** argv) {
   /* TODO(natsunoyoru97): It seems that the result is not as expected.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,16 +88,9 @@ void ExecuteDb(const std::string& command,
 
 void InitGlog(const char* argv0) {
   google::InitGoogleLogging(argv0);
-  FLAGS_logtostderr = 1;
+  FLAGS_logtostderr = true;
 }
 
-// The string should bind to the stderr
-void TestGlog() {
-  LOG(INFO) << "The string should bind to the stderr in glog format."
-            << "\n";
-}
-
-void InitGflags() { std::cout << FLAGS_test << "\n"; }
 }  // namespace
 
 int main(int argc, char** argv) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,7 +62,7 @@ void ExecuteDb(const std::string& command,
   } else if (command == "delete") {
     Delete(params);
   } else if (command == "exit") {
-    LOG(INFO) << "Are you sure to exit? y/n"
+    std::cout << "Are you sure to exit? y/n"
               << "\n";
     while (true) {
       std::string c;
@@ -70,16 +70,19 @@ void ExecuteDb(const std::string& command,
       std::transform(c.begin(), c.end(), c.begin(), ::tolower);
 
       if (c == "y") {
-        LOG(INFO) << "Exit from the simple database cli." << std::endl;
+        std::cout << "Exit from the simple database cli."
+                  << "\n";
         exit(0);
       }
       if (c == "n") {
-        LOG(INFO) << "Cancel to exit." << std::endl;
+        std::cout << "Cancel to exit."
+                  << "\n";
         break;
       }
     }
   } else {
-    LOG(INFO) << "Invalid command." << std::endl;
+    std::cout << "Invalid command."
+              << "\n";
   }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ void TestGlog() {
             << "\n";
 }
 
-void InitGflags() { LOG(INFO) << FLAGS_test << "\n"; }
+void InitGflags() { std::cout << FLAGS_test << "\n"; }
 }  // namespace
 
 int main(int argc, char** argv) {
@@ -107,7 +107,7 @@ int main(int argc, char** argv) {
   TestGlog();
   InitGflags();
 
-  LOG(INFO) << argc << "\n";
+  std::cout << argc << "\n";
 
   while (true) {
     std::string command;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,7 +13,7 @@
 DEFINE_string(test, "simple database", "the flag for test");
 
 // Tokenizer that takes the space as the delimiter
-std::vector<std::string> Tokenize(const std::string& s) {
+static std::vector<std::string> Tokenize(const std::string& s) {
   std::vector<std::string> tokens;
   std::string curr;
   for (char c : s) {
@@ -35,24 +35,24 @@ std::vector<std::string> Tokenize(const std::string& s) {
   return tokens;
 }
 
-void Select(const std::vector<std::string>& params) {
-  std::cout << "This is select function." << std::endl;
+static void Select(const std::vector<std::string>& params) {
+  LOG(INFO) << "This is select function." << std::endl;
 
   for (const std::string& s : params) {
-    std::cout << s << " ";
+    LOG(INFO) << s << " ";
   }
-  std::cout << "\n";
+  LOG(INFO) << "\n";
 }
 
-void Insert(const std::vector<std::string>& params) {
-  std::cout << "This is insert function." << std::endl;
+static void Insert(const std::vector<std::string>& params) {
+  LOG(INFO) << "This is insert function." << params[0] << std::endl;
 }
 
-void Delete(const std::vector<std::string>& params) {
-  std::cout << "This is delete function." << std::endl;
+static void Delete(const std::vector<std::string>& params) {
+  LOG(INFO) << "This is delete function." << params[0] << std::endl;
 }
 
-void ExecuteDb(const std::string& command,
+static void ExecuteDb(const std::string& command,
                const std::vector<std::string>& params) {
   if (command == "select") {
     Select(params);
@@ -61,7 +61,7 @@ void ExecuteDb(const std::string& command,
   } else if (command == "delete") {
     Delete(params);
   } else if (command == "exit") {
-    std::cout << "Are you sure to exit? y/n"
+    LOG(INFO) << "Are you sure to exit? y/n"
               << "\n";
     while (true) {
       std::string c;
@@ -69,41 +69,44 @@ void ExecuteDb(const std::string& command,
       std::transform(c.begin(), c.end(), c.begin(), ::tolower);
 
       if (c == "y") {
-        std::cout << "Exit from the simple database cli." << std::endl;
+        LOG(INFO) << "Exit from the simple database cli." << std::endl;
         exit(0);
       }
       if (c == "n") {
-        std::cout << "Cancel to exit." << std::endl;
+        LOG(INFO) << "Cancel to exit." << std::endl;
         break;
       }
     }
   } else {
-    std::cout << "Invalid command." << std::endl;
+    LOG(INFO) << "Invalid command." << std::endl;
   }
 }
 
-// The signal handler for SIGPIPE
-void DoNothing(int signum) {
-  std::cout << "SIGPIPE"
-            << "\n"; /* Ignore SIGPIPE */
+static void InitGlog(const char* argv0) {
+  google::InitGoogleLogging(argv0);
+  FLAGS_logtostderr = 1;
 }
 
-// TODO(natsunoyoru97): redirect glog to stderr
-void InitGlog(const char* argv0) { google::InitGoogleLogging(argv0); }
+// The string should bind to the stderr
+static void TestGlog() {
+  LOG(INFO) << "The string should bind to the stderr in glog format." << "\n";
+}
 
-void InitGflags() {
-  // TODO(natsunoyoru97): Use glog to replace the cout
-  std::cout << FLAGS_test << "\n";
+static void InitGflags() {
+  LOG(INFO) << FLAGS_test << "\n";
 }
 
 int main(int argc, char** argv) {
   /* TODO(natsunoyoru97): It seems that the result is not as expected.
    It is a bug to fix.
    */
-  std::signal(SIGPIPE, DoNothing);
+  std::signal(SIGPIPE, SIG_IGN);
 
   InitGlog(argv[0]);
+  TestGlog();
   InitGflags();
+
+  LOG(INFO) << argc << "\n";
 
   while (true) {
     std::string command;
@@ -113,7 +116,7 @@ int main(int argc, char** argv) {
     std::string param;
 
     getline(std::cin, param);
-    std::cout << param << "\n";
+    LOG(INFO) << param << "\n";
 
     ExecuteDb(command, Tokenize(param));
   }


### PR DESCRIPTION
### Why we have the PR
To bind glog log to the stderr and show these logs on the terminal.

### What this PR did
- Bind log to stderr on `InitGlog`
- Declare all the functions on `src/main.cpp` to be static, because these functions are not intended to be used outside of this translation unit
- Print out all unused variables to pass the lints (These variables will probably be removed)
- Replace all the `std::cout` on `src/main.cpp` to `LOG(INFO)`
- Delete a redundant function `DoNothing`
- Delete two functions for test in prod code

### Testcase
- Test whether glog works
```c++
// The string should bind to the stderr
static void TestGlog() {
  LOG(INFO) << "The string should bind to the stderr in glog format." << "\n";
}
```
The log on the terminal for this function is expected to be something like this:
```
I20230113 21:28:37.742560  7786 main.cpp:92] The string should bind to the stderr in glog format.
```
- Test whether gflags works
```c++
void InitGflags() { std::cout << FLAGS_test << "\n"; }
```
The `FLAGS_test` will be printed out on the terminal if it works.